### PR TITLE
Update deploy_app.yml to affect desired count and healthy percent.

### DIFF
--- a/tasks/deploy_app.yml
+++ b/tasks/deploy_app.yml
@@ -88,7 +88,11 @@
     state: update
     name: "{{ cf_stack.stack_outputs.TodobackendService }}"
     cluster: "{{ cf_stack.stack_outputs.EcsCluster }}"
-    task_definition: "{{ todobackend_task_def_arn }}" 
+    task_definition: "{{ todobackend_task_def_arn }}"
+    desired_count: "{{ instance_count | default(1) }}"
+    deployment_config: 
+      minimumHealthyPercent: 50
+      maximumPercent: 200
   register: update_ecs_service
   when: image_tag is defined
 - debug: msg={{ update_ecs_service }}


### PR DESCRIPTION
Specifying desired count and healthy percent for 'reconfigure service' and not in 'deploy service update' causes the ECS service to default to 1 and health percent reset to 100% and 200%. Setting it on 'deploy service update' resolves the issue.